### PR TITLE
Suppress invalid Rubocop offences

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -11,6 +11,10 @@ AllCops:
   DisplayCopNames: false
   StyleGuideCopsOnly: false
   TargetRubyVersion: 2.3
+  Exclude:
+    - bin/bundle
+    - bin/rake
+    - bin/rspec
 Rails:
   Enabled: false
 

--- a/lib/rspec/pgp_matchers/be_a_pgp_encrypted_message.rb
+++ b/lib/rspec/pgp_matchers/be_a_pgp_encrypted_message.rb
@@ -17,7 +17,10 @@
 # running in a separate process may leverage GPGME, as it won't be exposed
 # outside the validator.  A previous implementation of this matcher may provide
 # some useful ideas.  See commit 2e2bd0da090d7d31ecacc2d1ea6bd3e13479e675.
+#
+# rubocop:disable Metrics/BlockLength
 RSpec::Matchers.define :be_a_pgp_encrypted_message do
+  # rubocop:enable Metrics/BlockLength
   include RSpec::PGPMatchers::GPGMatcherHelper
 
   attr_reader :err, :expected_recipients

--- a/lib/rspec/pgp_matchers/be_a_valid_pgp_signature_of.rb
+++ b/lib/rspec/pgp_matchers/be_a_valid_pgp_signature_of.rb
@@ -16,7 +16,10 @@
 # in a separate process may leverage GPGME, as it won't be exposed outside
 # the validator.  A previous implementation of this matcher may provide some
 # useful ideas.  See commit 2e2bd0da090d7d31ecacc2d1ea6bd3e13479e675.
+#
+# rubocop:disable Metrics/BlockLength
 RSpec::Matchers.define :be_a_valid_pgp_signature_of do |text|
+  # rubocop:enable Metrics/BlockLength
   include RSpec::PGPMatchers::GPGMatcherHelper
 
   attr_reader :err


### PR DESCRIPTION
- Allow for long blocks in matchers definition
- Suppress all offences in binstubs as they require unreasonable amount of changes, and are autogenerated anyway.