### PR TITLE
Specify missing Rspec-expectations dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -64,5 +64,14 @@ before_script:
   - bundle exec rake pgp_keys:list
 
 matrix:
+  include:
+    - gemfile: ci/gemfiles/rspec-3.7.gemfile
+      rvm: 2.5
+    - gemfile: ci/gemfiles/rspec-3.6.gemfile
+      rvm: 2.5
+    - gemfile: ci/gemfiles/rspec-3.5.gemfile
+      rvm: 2.5
+    - gemfile: ci/gemfiles/rspec-3.4.gemfile
+      rvm: 2.5
   allow_failures:
     - rvm: ruby-head

--- a/ci/gemfiles/common.gemfile
+++ b/ci/gemfiles/common.gemfile
@@ -1,0 +1,6 @@
+source "https://rubygems.org"
+
+gemspec path: "../.."
+
+gem "codecov", require: false
+gem "simplecov", require: false

--- a/ci/gemfiles/rspec-3.4.gemfile
+++ b/ci/gemfiles/rspec-3.4.gemfile
@@ -1,0 +1,5 @@
+# rubocop:disable Security/Eval
+eval File.read(File.expand_path("common.gemfile", __dir__))
+# rubocop:enable Security/Eval
+
+gem "rspec-expectations", "~> 3.4.0"

--- a/ci/gemfiles/rspec-3.5.gemfile
+++ b/ci/gemfiles/rspec-3.5.gemfile
@@ -1,0 +1,5 @@
+# rubocop:disable Security/Eval
+eval File.read(File.expand_path("common.gemfile", __dir__))
+# rubocop:enable Security/Eval
+
+gem "rspec-expectations", "~> 3.5.0"

--- a/ci/gemfiles/rspec-3.6.gemfile
+++ b/ci/gemfiles/rspec-3.6.gemfile
@@ -1,0 +1,5 @@
+# rubocop:disable Security/Eval
+eval File.read(File.expand_path("common.gemfile", __dir__))
+# rubocop:enable Security/Eval
+
+gem "rspec-expectations", "~> 3.6.0"

--- a/ci/gemfiles/rspec-3.7.gemfile
+++ b/ci/gemfiles/rspec-3.7.gemfile
@@ -1,0 +1,5 @@
+# rubocop:disable Security/Eval
+eval File.read(File.expand_path("common.gemfile", __dir__))
+# rubocop:enable Security/Eval
+
+gem "rspec-expectations", "~> 3.7.0"

--- a/rspec-pgp_matchers.gemspec
+++ b/rspec-pgp_matchers.gemspec
@@ -27,6 +27,8 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
+  spec.add_runtime_dependency "rspec-expectations", "~> 3.8"
+
   spec.add_development_dependency "bundler", "~> 1.16"
   spec.add_development_dependency "gpgme"
   spec.add_development_dependency "pry", ">= 0.10.3", "< 0.12"

--- a/rspec-pgp_matchers.gemspec
+++ b/rspec-pgp_matchers.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency "rspec-expectations", "~> 3.8"
+  spec.add_runtime_dependency "rspec-expectations", "~> 3.4"
 
   spec.add_development_dependency "bundler", "~> 1.16"
   spec.add_development_dependency "gpgme"


### PR DESCRIPTION
Also, make sure that this gem passes tests against all versions of rspec-expectations from 3.4.