### PR TITLE
Extract GPGRunner, and make it a part of public API

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -86,6 +86,28 @@ expect(encrypted).to be_a_pgp_encrypted_message.encrypted_for(recipient1_uid, re
 expect(encrypted).to be_a_pgp_encrypted_message.encrypted_for(someones_uid)
 ----
 
+=== Running arbitrary GnuPG commands
+
+An `RSpec::PGPMatchers::GPGRunner` module can be used to run arbitrary GnuPG
+commands:
+
+[source,ruby]
+----
+RSpec::PGPMatchers::GPGRunner.run_command("--decrypt PATH_TO_FILE")
+RSpec::PGPMatchers::GPGRunner.run_command("--list-keys")
+----
+
+Also, convenient helpers are defined for two common commands:
+
+[source,ruby]
+----
+RSpec::PGPMatchers::GPGRunner.run_decrypt("encrypted_string")
+RSpec::PGPMatchers::GPGRunner.run_verify("cleartext", "signature_string")
+----
+
+In all above cases, a triple consisting of captured standard output, captured
+standard error, and `Process::Status` instance is returned.
+
 == Development
 
 After checking out the repo, run `bin/setup` to install dependencies.

--- a/lib/rspec/pgp_matchers.rb
+++ b/lib/rspec/pgp_matchers.rb
@@ -3,6 +3,7 @@
 
 require "rspec/pgp_matchers/version"
 require "rspec/pgp_matchers/gpg_matcher_helper"
+require "rspec/pgp_matchers/gpg_runner"
 require "rspec/pgp_matchers/be_a_pgp_encrypted_message"
 require "rspec/pgp_matchers/be_a_valid_pgp_signature_of"
 

--- a/lib/rspec/pgp_matchers/be_a_pgp_encrypted_message.rb
+++ b/lib/rspec/pgp_matchers/be_a_pgp_encrypted_message.rb
@@ -77,15 +77,8 @@ RSpec::Matchers.define :be_a_pgp_encrypted_message do
   end
 
   def gpg_decrypt_command(enc_file)
-    homedir_path = Shellwords.escape(RSpec::PGPMatchers.homedir)
     enc_path = Shellwords.escape(enc_file.path)
-
-    <<~SH
-      gpg \
-      --homedir #{homedir_path} \
-      --no-permission-warning \
-      --decrypt #{enc_path}
-    SH
+    "--decrypt #{enc_path}"
   end
 
   def msg_mismatch(text)

--- a/lib/rspec/pgp_matchers/be_a_pgp_encrypted_message.rb
+++ b/lib/rspec/pgp_matchers/be_a_pgp_encrypted_message.rb
@@ -43,7 +43,7 @@ RSpec::Matchers.define :be_a_pgp_encrypted_message do
 
   # Returns +nil+ if signature is valid, or an error message otherwise.
   def validate_encrypted_message(encrypted_string)
-    cmd_output = run_gpg_decrypt(encrypted_string)
+    cmd_output = run_decrypt(encrypted_string)
     cmd_result = analyse_decrypt_output(*cmd_output)
 
     if cmd_result[:well_formed_pgp_data]
@@ -51,12 +51,6 @@ RSpec::Matchers.define :be_a_pgp_encrypted_message do
     else
       msg_no_pgg_data(encrypted_string)
     end
-  end
-
-  def run_gpg_decrypt(encrypted_string)
-    enc_file = make_tempfile_containing(encrypted_string)
-    cmd = gpg_decrypt_command(enc_file)
-    run_command(cmd)
   end
 
   def analyse_decrypt_output(stdout_str, stderr_str, status)
@@ -74,11 +68,6 @@ RSpec::Matchers.define :be_a_pgp_encrypted_message do
       (expected_recipients && match_recipients(recipients)),
       (expected_signer && match_signature(signature)),
     ].detect { |x| x }
-  end
-
-  def gpg_decrypt_command(enc_file)
-    enc_path = Shellwords.escape(enc_file.path)
-    "--decrypt #{enc_path}"
   end
 
   def msg_mismatch(text)

--- a/lib/rspec/pgp_matchers/be_a_valid_pgp_signature_of.rb
+++ b/lib/rspec/pgp_matchers/be_a_valid_pgp_signature_of.rb
@@ -66,16 +66,9 @@ RSpec::Matchers.define :be_a_valid_pgp_signature_of do |text|
   end
 
   def gpg_verify_command(sig_file, data_file)
-    homedir_path = Shellwords.escape(RSpec::PGPMatchers.homedir)
     sig_path = Shellwords.escape(sig_file.path)
     data_path = Shellwords.escape(data_file.path)
-
-    <<~SH
-      gpg \
-      --homedir #{homedir_path} \
-      --no-permission-warning \
-      --verify #{sig_path} #{data_path}
-    SH
+    "--verify #{sig_path} #{data_path}"
   end
 
   def msg_mismatch(text)

--- a/lib/rspec/pgp_matchers/be_a_valid_pgp_signature_of.rb
+++ b/lib/rspec/pgp_matchers/be_a_valid_pgp_signature_of.rb
@@ -37,7 +37,7 @@ RSpec::Matchers.define :be_a_valid_pgp_signature_of do |text|
 
   # Returns +nil+ if first signature is valid, or an error message otherwise.
   def verify_signature(cleartext, signature_string)
-    cmd_output = run_gpg_verify(cleartext, signature_string)
+    cmd_output = run_verify(cleartext, signature_string)
     cmd_result = analyse_verify_output(*cmd_output)
 
     if cmd_result[:well_formed_pgp_data]
@@ -45,13 +45,6 @@ RSpec::Matchers.define :be_a_valid_pgp_signature_of do |text|
     else
       msg_no_pgg_data(signature_string)
     end
-  end
-
-  def run_gpg_verify(cleartext, signature_string)
-    sig_file = make_tempfile_containing(signature_string)
-    data_file = make_tempfile_containing(cleartext)
-    cmd = gpg_verify_command(sig_file, data_file)
-    run_command(cmd)
   end
 
   def analyse_verify_output(_stdout_str, stderr_str, status)
@@ -63,12 +56,6 @@ RSpec::Matchers.define :be_a_valid_pgp_signature_of do |text|
 
   def match_constraints(signature:, **_ignored)
     match_signature(signature)
-  end
-
-  def gpg_verify_command(sig_file, data_file)
-    sig_path = Shellwords.escape(sig_file.path)
-    data_path = Shellwords.escape(data_file.path)
-    "--verify #{sig_path} #{data_path}"
   end
 
   def msg_mismatch(text)

--- a/lib/rspec/pgp_matchers/gpg_matcher_helper.rb
+++ b/lib/rspec/pgp_matchers/gpg_matcher_helper.rb
@@ -7,6 +7,10 @@ require "tempfile"
 module RSpec
   module PGPMatchers
     module GPGMatcherHelper
+      extend Forwardable
+
+      def_delegators :"RSpec::PGPMatchers::GPGRunner", :run_verify, :run_decrypt
+
       def detect_signers(stderr_str)
         rx = /(?<ok>Good|BAD) signature from .*\<(?<email>[^>]+)\>/
 
@@ -46,25 +50,6 @@ module RSpec
         elsif expected_signer && signature[:email] != expected_signer
           msg_wrong_signer(signature[:email])
         end
-      end
-
-      def make_tempfile_containing(file_content)
-        tempfile = Tempfile.new
-        tempfile.write(file_content)
-        tempfile.flush
-      end
-
-      def run_command(gpg_cmd)
-        env = { "LC_ALL" => "C" } # Gettext English locale
-
-        homedir_path = Shellwords.escape(RSpec::PGPMatchers.homedir)
-
-        Open3.capture3(env, <<~SH)
-          gpg \
-          --homedir #{homedir_path} \
-          --no-permission-warning \
-          #{gpg_cmd}
-        SH
       end
     end
   end

--- a/lib/rspec/pgp_matchers/gpg_matcher_helper.rb
+++ b/lib/rspec/pgp_matchers/gpg_matcher_helper.rb
@@ -54,9 +54,17 @@ module RSpec
         tempfile.flush
       end
 
-      def run_command(cmd)
+      def run_command(gpg_cmd)
         env = { "LC_ALL" => "C" } # Gettext English locale
-        Open3.capture3(env, cmd)
+
+        homedir_path = Shellwords.escape(RSpec::PGPMatchers.homedir)
+
+        Open3.capture3(env, <<~SH)
+          gpg \
+          --homedir #{homedir_path} \
+          --no-permission-warning \
+          #{gpg_cmd}
+        SH
       end
     end
   end

--- a/lib/rspec/pgp_matchers/gpg_runner.rb
+++ b/lib/rspec/pgp_matchers/gpg_runner.rb
@@ -1,0 +1,58 @@
+# (c) Copyright 2018 Ribose Inc.
+#
+
+require "open3"
+require "tempfile"
+
+module RSpec
+  module PGPMatchers
+    module GPGRunner
+      class << self
+        def run_command(gpg_cmd)
+          env = { "LC_ALL" => "C" } # Gettext English locale
+
+          homedir_path = Shellwords.escape(RSpec::PGPMatchers.homedir)
+
+          Open3.capture3(env, <<~SH)
+            gpg \
+            --homedir #{homedir_path} \
+            --no-permission-warning \
+            #{gpg_cmd}
+          SH
+        end
+
+        def run_decrypt(encrypted_string)
+          enc_file = make_tempfile_containing(encrypted_string)
+          cmd = gpg_decrypt_command(enc_file)
+          run_command(cmd)
+        end
+
+        def run_verify(cleartext, signature_string)
+          sig_file = make_tempfile_containing(signature_string)
+          data_file = make_tempfile_containing(cleartext)
+          cmd = gpg_verify_command(sig_file, data_file)
+          run_command(cmd)
+        end
+
+        private
+
+        def make_tempfile_containing(file_content)
+          tempfile = Tempfile.new
+          tempfile.write(file_content)
+          tempfile.flush
+        end
+
+        def gpg_decrypt_command(enc_file)
+          enc_path = Shellwords.escape(enc_file.path)
+          "--decrypt #{enc_path}"
+        end
+
+        def gpg_verify_command(sig_file, data_file)
+          sig_path = Shellwords.escape(sig_file.path)
+          data_path = Shellwords.escape(data_file.path)
+          "--verify #{sig_path} #{data_path}"
+        end
+      end
+    end
+  end
+end

--- a/spec/gpg_runner_spec.rb
+++ b/spec/gpg_runner_spec.rb
@@ -1,0 +1,65 @@
+# (c) Copyright 2018 Ribose Inc.
+#
+
+require "spec_helper"
+
+RSpec.describe RSpec::PGPMatchers::GPGRunner do
+  let(:failure_exception) { RSpec::Expectations::ExpectationNotMetError }
+  let(:crypto) { ::GPGME::Crypto.new(crypto_opts) }
+  let(:text) { "text" }
+  let(:misspelled) { "teXt" }
+  let(:recipient) { "whatever@example.test" }
+  let(:signer) { "whatever@example.test" }
+
+  let(:crypto_opts) do
+    { armor: true, recipients: [recipient], signers: signer, sign: true }
+  end
+
+  before do
+    allow(described_class).to receive(:run_command).and_call_original
+  end
+
+  describe "#run_command" do
+    subject { described_class.method :run_command }
+
+    it "runs arbitrary GnuPG commands, and returns their captured standard " +
+      "output, error, and exit status" do
+      retval = subject.("--list-keys")
+      expect(retval[0]).to be_a(String) & match(/pubring/) & match(/Cato/)
+      expect(retval[1]).to be_a(String)
+      expect(retval[2]).to be_a(Process::Status) & be_success
+    end
+  end
+
+  describe "#run_decrypt" do
+    subject { described_class.method :run_decrypt }
+
+    let(:enc) { crypto.encrypt(text).to_s }
+
+    it "runs GnuPG decrypt command, and returns captured standard " +
+      "output, error, and exit status" do
+      retval = subject.(enc)
+      expect(described_class).to have_received(:run_command).
+        with(/^--decrypt\b/)
+      expect(retval[0]).to be_a(String) & eq(text)
+      expect(retval[1]).to be_a(String) & match(/^gpg: encrypted/)
+      expect(retval[2]).to be_a(Process::Status) & be_success
+    end
+  end
+
+  describe "#run_verify" do
+    subject { described_class.method :run_verify }
+
+    let(:sig) { crypto.detach_sign(text).to_s }
+
+    it "runs GnuPG decrypt command, and returns captured standard " +
+      "output, error, and exit status" do
+      retval = subject.(text, sig)
+      expect(described_class).to have_received(:run_command).
+        with(/^--verify\b/)
+      expect(retval[0]).to be_a(String)
+      expect(retval[1]).to be_a(String) & match(/^gpg: Good signature/)
+      expect(retval[2]).to be_a(Process::Status) & be_success
+    end
+  end
+end


### PR DESCRIPTION
Extract `GPGRunner` capable of running arbitrary GnuPG commands in a more less easy way. This feature is generally useful in tests and development, i.e. for preparing encrypted messages or signatures as test fixtures.