### PR TITLE
Allow Bundler 2.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -51,7 +51,6 @@ before_install:
     --configure-opts "${GPG_CONFIGURE_OPTS}"
     --folding-style travis
   - popd
-  - gem install bundler -v "~> 1.16"
 
 install:
   - bundle install --jobs=3 --retry=3 --path=${BUNDLE_PATH:-vendor/bundle}

--- a/rspec-pgp_matchers.gemspec
+++ b/rspec-pgp_matchers.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency "rspec-expectations", "~> 3.4"
 
-  spec.add_development_dependency "bundler", "~> 1.16"
+  spec.add_development_dependency "bundler", ">= 1.16"
   spec.add_development_dependency "gpgme"
   spec.add_development_dependency "pry", ">= 0.10.3", "< 0.12"
   spec.add_development_dependency "rake", "~> 12.0"


### PR DESCRIPTION
Bundler 2.0 has been released recently. This pull request relaxes development dependency constraint which is specified in gemspec in order to allow all 2.x and later versions.