### PR TITLE
Fix race conditions

### DIFF
--- a/lib/rspec/pgp_matchers/gpg_runner.rb
+++ b/lib/rspec/pgp_matchers/gpg_runner.rb
@@ -50,7 +50,8 @@ module RSpec
           # conditions, so let's go with the create method.
           tempfile = Tempfile.create("rspec-gpg-runner")
           tempfile.write(file_content)
-          tempfile.flush
+          tempfile.close
+          tempfile
         end
 
         def gpg_decrypt_command(enc_file)

--- a/lib/rspec/pgp_matchers/gpg_runner.rb
+++ b/lib/rspec/pgp_matchers/gpg_runner.rb
@@ -48,10 +48,10 @@ module RSpec
           #
           # Tempfile's surprise file removals were among causes of race
           # conditions, so let's go with the create method.
-          tempfile = Tempfile.create("rspec-gpg-runner")
-          tempfile.write(file_content)
-          tempfile.close
-          tempfile
+          file = Tempfile.create("rspec-gpg-runner")
+          file.write(file_content)
+          file.close
+          file
         end
 
         def gpg_decrypt_command(enc_file)


### PR DESCRIPTION
Strange issues have been reported in https://github.com/riboseinc/enmail/issues/119. Several system calls used to complain about file descriptor issues on a random basis.

It seems that there were some race conditions revolving around how temporary files are managed in this gem. Probably in some situations a temporary file was either partly created/written, or prematurely removed.

Switching from instances of `Tempfile` class to instances of `File` did help — the former may be removed by garbage collector, whereas the latter must be removed explicitly. Also, these files are now closed properly after writing their content.

Thanks to these improvements, EnMail builds now always pass for all stable MRI versions from 2.3 to 2.6. However, builds for `ruby-head` still fail consequently with some file descriptor errors. It is unknown whether it's a regression in Ruby HEAD, or another bug in EnMail, or in this very gem. A thing worth noting is that these builds always fail in the same two examples and LOCs, which is different from previous issues (random failures).