### PR TITLE
Use #eval_gemfile in gemfiles

### DIFF
--- a/ci/gemfiles/rspec-3.4.gemfile
+++ b/ci/gemfiles/rspec-3.4.gemfile
@@ -1,5 +1,3 @@
-# rubocop:disable Security/Eval
-eval File.read(File.expand_path("common.gemfile", __dir__))
-# rubocop:enable Security/Eval
+eval_gemfile "common.gemfile"
 
 gem "rspec-expectations", "~> 3.4.0"

--- a/ci/gemfiles/rspec-3.5.gemfile
+++ b/ci/gemfiles/rspec-3.5.gemfile
@@ -1,5 +1,3 @@
-# rubocop:disable Security/Eval
-eval File.read(File.expand_path("common.gemfile", __dir__))
-# rubocop:enable Security/Eval
+eval_gemfile "common.gemfile"
 
 gem "rspec-expectations", "~> 3.5.0"

--- a/ci/gemfiles/rspec-3.6.gemfile
+++ b/ci/gemfiles/rspec-3.6.gemfile
@@ -1,5 +1,3 @@
-# rubocop:disable Security/Eval
-eval File.read(File.expand_path("common.gemfile", __dir__))
-# rubocop:enable Security/Eval
+eval_gemfile "common.gemfile"
 
 gem "rspec-expectations", "~> 3.6.0"

--- a/ci/gemfiles/rspec-3.7.gemfile
+++ b/ci/gemfiles/rspec-3.7.gemfile
@@ -1,5 +1,3 @@
-# rubocop:disable Security/Eval
-eval File.read(File.expand_path("common.gemfile", __dir__))
-# rubocop:enable Security/Eval
+eval_gemfile "common.gemfile"
 
 gem "rspec-expectations", "~> 3.7.0"


### PR DESCRIPTION
Replace `Kernel#eval` with `#eval_gemfile` from Bundler's DSL.