### PR TITLE
Make GnuPG path customizable

### DIFF
--- a/lib/rspec/pgp_matchers.rb
+++ b/lib/rspec/pgp_matchers.rb
@@ -9,7 +9,10 @@ require "rspec/pgp_matchers/be_a_valid_pgp_signature_of"
 
 module RSpec
   module PGPMatchers
+    @gpg_path = "gpg"
+
     class << self
+      attr_accessor :gpg_path
       attr_accessor :homedir
     end
     # Your code goes here...

--- a/lib/rspec/pgp_matchers/gpg_runner.rb
+++ b/lib/rspec/pgp_matchers/gpg_runner.rb
@@ -11,10 +11,11 @@ module RSpec
         def run_command(gpg_cmd)
           env = { "LC_ALL" => "C" } # Gettext English locale
 
+          gpg_path = Shellwords.escape(RSpec::PGPMatchers.gpg_path)
           homedir_path = Shellwords.escape(RSpec::PGPMatchers.homedir)
 
           Open3.capture3(env, <<~SH)
-            gpg \
+            #{gpg_path} \
             --homedir #{homedir_path} \
             --no-permission-warning \
             #{gpg_cmd}

--- a/spec/gpg_runner_spec.rb
+++ b/spec/gpg_runner_spec.rb
@@ -29,6 +29,12 @@ RSpec.describe RSpec::PGPMatchers::GPGRunner do
       expect(retval[1]).to be_a(String)
       expect(retval[2]).to be_a(Process::Status) & be_success
     end
+
+    it "calls a GnuPG executable specified by RSpec::PGPMatchers.gpg_path" do
+      allow(RSpec::PGPMatchers).to receive(:gpg_path).and_return("path/to/gpg")
+      allow(Open3).to receive(:capture3).with(anything, %r[^path/to/gpg])
+      subject.("--some-command")
+    end
   end
 
   describe "#run_decrypt" do

--- a/spec/gpg_runner_spec.rb
+++ b/spec/gpg_runner_spec.rb
@@ -35,6 +35,13 @@ RSpec.describe RSpec::PGPMatchers::GPGRunner do
       allow(Open3).to receive(:capture3).with(anything, %r[^path/to/gpg])
       subject.("--some-command")
     end
+
+    it "calls a GnuPG executable specified by RSpec::PGPMatchers.homedir" do
+      allow(RSpec::PGPMatchers).to receive(:homedir).and_return("path/to/home")
+      allow(Open3).to receive(:capture3).
+        with(anything, %r[--homedir path/to/home])
+      subject.("--some-command")
+    end
   end
 
   describe "#run_decrypt" do

--- a/spec/rspec_pgp_matchers_spec.rb
+++ b/spec/rspec_pgp_matchers_spec.rb
@@ -15,4 +15,16 @@ RSpec.describe RSpec::PGPMatchers do
       to change { RSpec::PGPMatchers.homedir }.to("some/path")
     RSpec::PGPMatchers.homedir = homedir_preserve
   end
+
+  # This test would break others if run in parallel
+  it "has configurable path to GPG executable" do
+    gpg_path_preserve = RSpec::PGPMatchers.gpg_path
+    expect { RSpec::PGPMatchers.gpg_path = "some/path" }.
+      to change { RSpec::PGPMatchers.gpg_path }.to("some/path")
+    RSpec::PGPMatchers.gpg_path = gpg_path_preserve
+  end
+
+  it "has a default value for gpg_path" do
+    expect(RSpec::PGPMatchers.gpg_path).to eq("gpg")
+  end
 end


### PR DESCRIPTION
Allow for specifying custom names of the GnuPG executable.  This is primarily intended to be used when GnuPG executable file name has a custom suffix (e.g. `gpg2`, `gpg-custom`).  The absolute path to GnuPG executable can be specified this way, but usually altering `PATH` environment variable is a cleaner solution.