### PR TITLE
Rename configuration option gpg_path to gpg_executable

### DIFF
--- a/lib/rspec/pgp_matchers.rb
+++ b/lib/rspec/pgp_matchers.rb
@@ -9,10 +9,10 @@ require "rspec/pgp_matchers/be_a_valid_pgp_signature_of"
 
 module RSpec
   module PGPMatchers
-    @gpg_path = "gpg"
+    @gpg_executable = "gpg"
 
     class << self
-      attr_accessor :gpg_path
+      attr_accessor :gpg_executable
       attr_accessor :homedir
     end
     # Your code goes here...

--- a/lib/rspec/pgp_matchers/gpg_runner.rb
+++ b/lib/rspec/pgp_matchers/gpg_runner.rb
@@ -11,11 +11,11 @@ module RSpec
         def run_command(gpg_cmd)
           env = { "LC_ALL" => "C" } # Gettext English locale
 
-          gpg_path = Shellwords.escape(RSpec::PGPMatchers.gpg_path)
+          gpg_executable = Shellwords.escape(RSpec::PGPMatchers.gpg_executable)
           homedir_path = Shellwords.escape(RSpec::PGPMatchers.homedir)
 
           Open3.capture3(env, <<~SH)
-            #{gpg_path} \
+            #{gpg_executable} \
             --homedir #{homedir_path} \
             --no-permission-warning \
             #{gpg_cmd}

--- a/spec/gpg_runner_spec.rb
+++ b/spec/gpg_runner_spec.rb
@@ -31,7 +31,8 @@ RSpec.describe RSpec::PGPMatchers::GPGRunner do
     end
 
     it "calls the executable specified by RSpec::PGPMatchers.gpg_executable" do
-      allow(RSpec::PGPMatchers).to receive(:gpg_executable).and_return("path/to/gpg")
+      allow(RSpec::PGPMatchers).to receive(:gpg_executable).
+        and_return("path/to/gpg")
       allow(Open3).to receive(:capture3).with(anything, %r[^path/to/gpg])
       subject.("--some-command")
     end

--- a/spec/gpg_runner_spec.rb
+++ b/spec/gpg_runner_spec.rb
@@ -30,13 +30,13 @@ RSpec.describe RSpec::PGPMatchers::GPGRunner do
       expect(retval[2]).to be_a(Process::Status) & be_success
     end
 
-    it "calls a GnuPG executable specified by RSpec::PGPMatchers.gpg_executable" do
+    it "calls the executable specified by RSpec::PGPMatchers.gpg_executable" do
       allow(RSpec::PGPMatchers).to receive(:gpg_executable).and_return("path/to/gpg")
       allow(Open3).to receive(:capture3).with(anything, %r[^path/to/gpg])
       subject.("--some-command")
     end
 
-    it "calls a GnuPG executable specified by RSpec::PGPMatchers.homedir" do
+    it "calls the executable specified by RSpec::PGPMatchers.homedir" do
       allow(RSpec::PGPMatchers).to receive(:homedir).and_return("path/to/home")
       allow(Open3).to receive(:capture3).
         with(anything, %r[--homedir path/to/home])

--- a/spec/gpg_runner_spec.rb
+++ b/spec/gpg_runner_spec.rb
@@ -30,8 +30,8 @@ RSpec.describe RSpec::PGPMatchers::GPGRunner do
       expect(retval[2]).to be_a(Process::Status) & be_success
     end
 
-    it "calls a GnuPG executable specified by RSpec::PGPMatchers.gpg_path" do
-      allow(RSpec::PGPMatchers).to receive(:gpg_path).and_return("path/to/gpg")
+    it "calls a GnuPG executable specified by RSpec::PGPMatchers.gpg_executable" do
+      allow(RSpec::PGPMatchers).to receive(:gpg_executable).and_return("path/to/gpg")
       allow(Open3).to receive(:capture3).with(anything, %r[^path/to/gpg])
       subject.("--some-command")
     end

--- a/spec/rspec_pgp_matchers_spec.rb
+++ b/spec/rspec_pgp_matchers_spec.rb
@@ -18,13 +18,13 @@ RSpec.describe RSpec::PGPMatchers do
 
   # This test would break others if run in parallel
   it "has configurable path to GPG executable" do
-    gpg_path_preserve = RSpec::PGPMatchers.gpg_path
-    expect { RSpec::PGPMatchers.gpg_path = "some/path" }.
-      to change { RSpec::PGPMatchers.gpg_path }.to("some/path")
-    RSpec::PGPMatchers.gpg_path = gpg_path_preserve
+    gpg_executable_preserve = RSpec::PGPMatchers.gpg_executable
+    expect { RSpec::PGPMatchers.gpg_executable = "some/path" }.
+      to change { RSpec::PGPMatchers.gpg_executable }.to("some/path")
+    RSpec::PGPMatchers.gpg_executable = gpg_executable_preserve
   end
 
-  it "has a default value for gpg_path" do
-    expect(RSpec::PGPMatchers.gpg_path).to eq("gpg")
+  it "has a default value for gpg_executable" do
+    expect(RSpec::PGPMatchers.gpg_executable).to eq("gpg")
   end
 end


### PR DESCRIPTION
The new name better reflects what this setting is about, and does not suggest that its value must be a fully qualified path.